### PR TITLE
Add .eslintignore file.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/node_modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "HTTP API for Bedrock User Accounts",
   "main": "./lib",
   "scripts": {
-    "lint": "eslint lib test"
+    "lint": "eslint lib test schemas"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "HTTP API for Bedrock User Accounts",
   "main": "./lib",
   "scripts": {
-    "lint": "eslint **/*.js"
+    "lint": "eslint lib test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@aljones15 I found that this works for being able to test files in folders of arbitrary depth in `lib` and `test` folder.