### PR TITLE
Update bedrock passport to the latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bedrock": "1.12.1 - 3.x",
     "bedrock-account": "2.x - 4.x",
     "bedrock-express": "2.0.8 - 3.x",
-    "bedrock-passport": "4.x - 5.x",
+    "bedrock-passport": "5.x - 6.x",
     "bedrock-validation": "^4.4.0"
   },
   "directories": {
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "eslint": "^7.3.1",
-    "eslint-config-digitalbazaar": "^2.0.1"
+    "eslint-config-digitalbazaar": "^2.5.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -31,7 +31,7 @@
     "bedrock-account-http": "file:..",
     "bedrock-express": "^3.2.0",
     "bedrock-mongodb": "^7.1.0",
-    "bedrock-passport": "github:digitalbazaar/bedrock-passport#update-bedrock-account",
+    "bedrock-passport": "^6.0.0",
     "bedrock-permission": "^3.0.0",
     "bedrock-rest": "^3.0.0",
     "bedrock-server": "^2.6.0",


### PR DESCRIPTION
Addresses #31 and #30 
Mongodb stuff are all up to date. No findOne or other api calls. 
- Updated bedrock-passport to latest, since it was using a branch which is no longer active by mistake.